### PR TITLE
v3.0.4 -> v3.0.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 # History
+## v3.0.5 (13-11-23)
+* Fixes bug where StudyInstanceUID-only QIDO-RS HierarchicalQuery would remove UID from query
+* Fixes bug where Series-level QIDO-RS RelationalQuery returns Study-level result
+
 ## v3.0.4 (25-09-23)
 * Fixes build error in 3.0.3 github actions. No code changes
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dicomtrolley"
-version = "3.0.4"
+version = "3.0.5"
 description = "Retrieve medical images via WADO-URI, WADO-RS, QIDO-RS, MINT, RAD69 and DICOM-QR"
 authors = ["sjoerdk <sjoerd.kerkstra@radboudumc.nl>"]
 readme = "README.md"


### PR DESCRIPTION
* Fixes bug where StudyInstanceUID-only QIDO-RS HierarchicalQuery would remove UID from query
* Fixes bug where Series-level QIDO-RS RelationalQuery returns Study-level result