### PR TITLE
V3.2.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 # History
+## v3.2.1 (02-06-24)
+* WADO-RS Downloader now raises DICOMTrolleyError instead of OSErron parsing faulty dicom responses. Fixes #58
+
 ## v3.2.0 (17-09-24)
 * Moves to pydantic v2, releases pydantic 1.8.2 pin. See #54
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dicomtrolley"
-version = "3.2.0"
+version = "3.2.1"
 description = "Retrieve medical images via WADO-URI, WADO-RS, QIDO-RS, MINT, RAD69 and DICOM-QR"
 authors = ["sjoerdk <sjoerd.kerkstra@radboudumc.nl>"]
 readme = "README.md"


### PR DESCRIPTION
## v3.2.1 (02-06-24)
* WADO-RS Downloader now raises DICOMTrolleyError instead of OSErron parsing faulty dicom responses. Fixes #58